### PR TITLE
Fix operation name bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export function create_client<T>(send: (body: { operationName: string, query: st
         }
         let operationName = (match[2] || '').trim();
         if (!operationName) {
-            operationName = random_name();
+            operationName = 'op'+random_name();
         }
         query = query.replace(match[0], `${match[1]} ${operationName}${match[3]==='(' ? '(' : ' {'}`);
         query = detect_fragments(query);


### PR DESCRIPTION
most of graphql servers do not allow operation name to start with number, so I propose to prefix random name with some characters to guarantee name will not start with numbers